### PR TITLE
Feature/singleton pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "angular 2 clipboard",
   "main": "./dist/bundles/ngxClipboard.umd.min.js",
   "module": "./dist/index.js",
-  "version": "0.0.0",
+  "version": "6.1.0-beta10",
   "author": {
     "name": "Sam Lin",
     "email": "maxisam@gmail.com"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "angular 2 clipboard",
   "main": "./dist/bundles/ngxClipboard.umd.min.js",
   "module": "./dist/index.js",
-  "version": "6.1.0-beta10",
+  "version": "0.0.0",
   "author": {
     "name": "Sam Lin",
     "email": "maxisam@gmail.com"

--- a/src/clipboard.directive.spec.ts
+++ b/src/clipboard.directive.spec.ts
@@ -33,7 +33,7 @@ describe('Directive: clipboard', () => {
       declarations: [TestClipboardComponent],
       imports: [
         BrowserModule,
-        ClipboardModule.forRoot(),
+        ClipboardModule,
         FormsModule]
     });
   });

--- a/src/clipboard.service.ts
+++ b/src/clipboard.service.ts
@@ -1,7 +1,7 @@
-import { element } from 'protractor';
+import { Provider } from '@angular/core/core';
 import { WindowSrv } from './window.service';
-import { Inject, Injectable, Renderer } from '@angular/core';
-import { DOCUMENT } from '@angular/platform-browser';
+import { Inject, Injectable, Renderer, Optional, SkipSelf } from '@angular/core';
+import { DOCUMENT } from "@angular/platform-browser";
 
 @Injectable()
 export class ClipboardService {
@@ -101,3 +101,14 @@ export class ClipboardService {
         return ta;
     }
 }
+// this pattern is mentioned in https://github.com/angular/angular/issues/13854 in #43
+export function CLIPBOARD_SERVICE_PROVIDER_FACTORY(
+    windowSrv: WindowSrv, parentDispatcher: ClipboardService) {
+    return parentDispatcher || new ClipboardService(new Inject(DOCUMENT), windowSrv);
+};
+
+export const CLIPBOARD_SERVICE_PROVIDER = {
+    provide: ClipboardService,
+    deps: [WindowSrv, [new Optional(), new SkipSelf(), ClipboardService]],
+    useFactory: CLIPBOARD_SERVICE_PROVIDER_FACTORY
+};

--- a/src/clipboard.service.ts
+++ b/src/clipboard.service.ts
@@ -1,7 +1,7 @@
-import { Provider } from '@angular/core/core';
 import { WindowSrv } from './window.service';
-import { Inject, Injectable, Renderer, Optional, SkipSelf } from '@angular/core';
-import { DOCUMENT } from "@angular/platform-browser";
+import { Inject, InjectionToken, Injectable, Optional, Renderer, SkipSelf } from '@angular/core';
+import { DOCUMENT } from '@angular/platform-browser';
+
 
 @Injectable()
 export class ClipboardService {
@@ -102,13 +102,12 @@ export class ClipboardService {
     }
 }
 // this pattern is mentioned in https://github.com/angular/angular/issues/13854 in #43
-export function CLIPBOARD_SERVICE_PROVIDER_FACTORY(
-    windowSrv: WindowSrv, parentDispatcher: ClipboardService) {
-    return parentDispatcher || new ClipboardService(new Inject(DOCUMENT), windowSrv);
+export function CLIPBOARD_SERVICE_PROVIDER_FACTORY(doc, windowSrv: WindowSrv, parentDispatcher: ClipboardService) {
+    return parentDispatcher || new ClipboardService(doc, windowSrv);
 };
 
 export const CLIPBOARD_SERVICE_PROVIDER = {
     provide: ClipboardService,
-    deps: [WindowSrv, [new Optional(), new SkipSelf(), ClipboardService]],
+    deps: [DOCUMENT, WindowSrv, [new Optional(), new SkipSelf(), ClipboardService]],
     useFactory: CLIPBOARD_SERVICE_PROVIDER_FACTORY
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,6 @@ export * from './clipboard.service';
     declarations: [ClipboardDirective],
     exports: [ClipboardDirective],
     imports: [CommonModule],
-    providers: [CLIPBOARD_SERVICE_PROVIDER]
+    providers: [WindowSrv, CLIPBOARD_SERVICE_PROVIDER]
 })
 export class ClipboardModule { }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,15 @@
-import { CommonModule } from '@angular/common';
 import { WindowSrv } from './window.service';
-import { ClipboardService } from './clipboard.service';
-import { ModuleWithProviders, NgModule } from '@angular/core';
 import { ClipboardDirective } from './clipboard.directive';
+import { CLIPBOARD_SERVICE_PROVIDER } from './clipboard.service';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 export * from './clipboard.directive';
 export * from './clipboard.service';
 
 @NgModule({
     declarations: [ClipboardDirective],
     exports: [ClipboardDirective],
-    imports: [CommonModule]
+    imports: [CommonModule],
+    providers: [CLIPBOARD_SERVICE_PROVIDER]
 })
-export class ClipboardModule {
-    public static forRoot(): ModuleWithProviders {
-        return {
-            ngModule: ClipboardModule,
-            providers: [ClipboardService, WindowSrv]
-        };
-    }
-}
+export class ClipboardModule { }


### PR DESCRIPTION
### Feature: 
base on #43, now it uses a new singleton pattern instead of forRoot pattern.

### Breaking Changes:

Remove forRoot() in imports.

`imports: [ClipboardModule]`