### PR TITLE
Fix using with TS --strict

### DIFF
--- a/src/clipboard.directive.ts
+++ b/src/clipboard.directive.ts
@@ -39,7 +39,7 @@ export class ClipboardDirective implements OnInit, OnDestroy {
      * Fires an event based on the copy operation result.
      * @param {Boolean} succeeded
      */
-    private handleResult(succeeded: Boolean, copiedContent: string) {
+    private handleResult(succeeded: Boolean, copiedContent: string | undefined) {
         if (succeeded) {
             this.cbOnSuccess.emit({ isSuccess: true, content: copiedContent });
         } else {

--- a/src/clipboard.service.ts
+++ b/src/clipboard.service.ts
@@ -5,7 +5,7 @@ import { WINDOW } from "ngx-window-token";
 
 @Injectable()
 export class ClipboardService {
-    private tempTextArea: HTMLTextAreaElement;
+    private tempTextArea: HTMLTextAreaElement | undefined;
     constructor(
         @Inject(DOCUMENT) private document: any,
         @Inject(WINDOW) private window: any,


### PR DESCRIPTION
When I use this project with TypeScript 2.4 and the --strict option it fails with:

```
ERROR in /Users/saul/projects/passit-frontend/node_modules/ngx-clipboard/src/clipboard.service.ts (59,13): Type 'undefined' is not assignable to type 'HTMLTextAreaElement'.

ERROR in /Users/saul/projects/passit-frontend/node_modules/ngx-clipboard/src/clipboard.directive.ts (29,38): Argument of type 'undefined' is not assignable to parameter of type 'string'.
```

This fixes those two errors.