### PR TITLE
replace index.ts with index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export { ClipboardModule, ClipboardDirective, ClipboardService } from './dist/index';

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,0 @@
-export { ClipboardModule, ClipboardDirective, ClipboardService } from './src/index';

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "README.md",
     "dist",
     "src",
-    "index.ts"
+    "index.d.ts"
   ],
   "config": {
     "commitizen": {


### PR DESCRIPTION
error TS6059 will occur when typescript app use this package and has compileOptions with "rootDir".

```
error TS6059:
Error File '/Users/adoo/projects/material-social-share/node_modules/ngx-clipboard/index.ts' is not under 'rootDir'
```
We needn't publish index.ts  and export `src` folder thing in it .  `src` folder only for sourceMap.
Use `index.d.ts` replace `index.ts`, and export `dist` can fix it.