### PR TITLE
docs(readme): add reference to angular renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Or
 
 Or
 
-You can just use copyFromContent from clipboard.service to copy any text you dynamically created.
+You can just use copyFromContent from clipboard.service to copy any text you dynamically created.  (the second parameter is the [Angular Renderer](https://angular.io/api/core/Renderer))
 
 **PLEASE CHECK WITH PLUNKER FIRST**
 


### PR DESCRIPTION
docs(readme): add reference to angular renderer

help users understand the renderer parameter