### PR TITLE
Update clipboard.service.ts

### DIFF
--- a/src/clipboard.service.ts
+++ b/src/clipboard.service.ts
@@ -9,7 +9,7 @@ export class ClipboardService {
         @Inject(DOCUMENT) private document: any,
         @Inject(WINDOW) private window: any,
     ) { }
-    public get isSupported(): boolean {
+    public isSupported(): boolean {
         return !!this.document.queryCommandSupported && !!this.document.queryCommandSupported('copy');
     }
 


### PR DESCRIPTION
The get method causes an error when attempting to implement angular universal
ERROR in C:/WildFyre/webcl/node_modules/ngx-clipboard/src/clipboard.service.ts (        12,16): Accessors are only available when targeting ECMAScript 5 and higher.
