### PR TITLE
fix: build with noUnusedLocals

### DIFF
--- a/src/clipboard.service.ts
+++ b/src/clipboard.service.ts
@@ -103,7 +103,11 @@ export function CLIPBOARD_SERVICE_PROVIDER_FACTORY(doc: Document, win: Window, p
 }
 
 export const CLIPBOARD_SERVICE_PROVIDER = {
-    deps: [DOCUMENT, WINDOW, [new Optional(), new SkipSelf(), ClipboardService]],
+    deps: [
+        DOCUMENT as InjectionToken<Document>,
+        WINDOW as InjectionToken<Document>,
+        [new Optional(), new SkipSelf(), ClipboardService]
+    ],
     provide: ClipboardService,
     useFactory: CLIPBOARD_SERVICE_PROVIDER_FACTORY
 };


### PR DESCRIPTION
This PR fixes #65.

By explicitly casting with `InjectionToken<Document>` in `clipboard.service.ts`, the TypeScript compiler doesn't fail when the `noUnusedLocals` compiler option is used.

Since there are no more unused locals in the project, the `noUnusedLocals` compiler option *could* be set to `true` in `tsconfig.json` and `tsconfig-build.json`. That step wasn't taken in this PR.