### PR TITLE
feat(package.json): Installation from git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "publish-npm:beta": "npm publish --tag=next",
     "semantic-release": "semantic-release pre && npm run publish-npm && semantic-release post",
     "sr": "npm run semantic-release",
-    "sr:beta": "semantic-release pre && npm run publish-npm:beta && semantic-release post"
+    "sr:beta": "semantic-release pre && npm run publish-npm:beta && semantic-release post",
+    "prepare": "npm run build"
   },
   "engines": {
     "node": ">=6.9.x"


### PR DESCRIPTION
Uses npm's `prepare` script to allow installing ngx-clipboard from a git repository.

The `prepare` script runs `npm run build` when this package is installed from a source repository.

A user can include ngx-clipboard in their application's `package.json` file like this:

```json
    ...
    "ngx-clipboard": "maxisam/ngx-clipboard#cool-branch",
    ...
```

This allows users to get the latest features and fixes, or use feature branches, before they get published to NPM.

From the NPM docs: https://docs.npmjs.com/cli/install

> If the package being installed contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.