### PR TITLE
fix: Renderer is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Or
 
 Or
 
-You can just use copyFromContent from clipboard.service to copy any text you dynamically created.  (the second parameter is the [Angular Renderer](https://angular.io/api/core/Renderer))
+You can just use copyFromContent from clipboard.service to copy any text you dynamically created.
 
 **PLEASE CHECK WITH PLUNKER FIRST**
 

--- a/src/clipboard.directive.ts
+++ b/src/clipboard.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output, Renderer } from '@angular/core';
+import { Directive, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
 
 import { ClipboardService } from './clipboard.service';
 
@@ -16,7 +16,6 @@ export class ClipboardDirective implements OnInit, OnDestroy {
     @Output() public cbOnError: EventEmitter<any> = new EventEmitter<any>();
     constructor(
         private clipboardSrv: ClipboardService,
-        private renderer: Renderer
 
     ) { }
 
@@ -31,10 +30,10 @@ export class ClipboardDirective implements OnInit, OnDestroy {
         if (!this.clipboardSrv.isSupported) {
             this.handleResult(false, undefined);
         } else if (this.targetElm && this.clipboardSrv.isTargetValid(this.targetElm)) {
-            this.handleResult(this.clipboardSrv.copyFromInputElement(this.targetElm, this.renderer),
+            this.handleResult(this.clipboardSrv.copyFromInputElement(this.targetElm),
                 this.targetElm.value);
         } else if (this.cbContent) {
-            this.handleResult(this.clipboardSrv.copyFromContent(this.cbContent, this.renderer), this.cbContent);
+            this.handleResult(this.clipboardSrv.copyFromContent(this.cbContent), this.cbContent);
         }
     }
 

--- a/src/clipboard.service.ts
+++ b/src/clipboard.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional, Renderer, SkipSelf, InjectionToken } from '@angular/core';
+import { Inject, Injectable, Optional, SkipSelf, InjectionToken } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
 import { WINDOW } from 'ngx-window-token';
 
@@ -27,9 +27,9 @@ export class ClipboardService {
     /**
      * copyFromInputElement
      */
-    public copyFromInputElement(targetElm: HTMLInputElement | HTMLTextAreaElement, renderer: Renderer): boolean {
+    public copyFromInputElement(targetElm: HTMLInputElement | HTMLTextAreaElement): boolean {
         try {
-            this.selectTarget(targetElm, renderer);
+            this.selectTarget(targetElm);
             const re = this.copyText();
             this.clearSelection(targetElm, this.window);
             return re;
@@ -42,13 +42,13 @@ export class ClipboardService {
      * Creates a fake textarea element, sets its value from `text` property,
      * and makes a selection on it.
      */
-    public copyFromContent(content: string, renderer: Renderer) {
+    public copyFromContent(content: string) {
         if (!this.tempTextArea) {
             this.tempTextArea = this.createTempTextArea(this.document, this.window);
             this.document.body.appendChild(this.tempTextArea);
         }
         this.tempTextArea.value = content;
-        return this.copyFromInputElement(this.tempTextArea, renderer);
+        return this.copyFromInputElement(this.tempTextArea);
     }
 
     // remove temporary textarea if any
@@ -60,9 +60,9 @@ export class ClipboardService {
     }
 
     // select the target html input element
-    private selectTarget(inputElement: HTMLInputElement | HTMLTextAreaElement, renderer: Renderer): number | undefined {
-        renderer.invokeElementMethod(inputElement, 'select');
-        renderer.invokeElementMethod(inputElement, 'setSelectionRange', [0, inputElement.value.length]);
+    private selectTarget(inputElement: HTMLInputElement | HTMLTextAreaElement): number | undefined {
+        inputElement.select();
+        inputElement.setSelectionRange(0, inputElement.value.length);
         return inputElement.value.length;
     }
 


### PR DESCRIPTION
Angular recommends using Renderer2 instead, but Renderer2 does not have invokeElementMethod

BREAKING CHANGE: Removed Renderer

fix #96