### PR TITLE
fix: demo code fails to run locally

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,6 @@
     "lib": [
       "es2017",
       "dom"
-    ],
-    "paths": {
-      "ngx-clipboard": [
-        "dist/ngx-clipboard"
-      ]
-    }
+    ]
   }
 }


### PR DESCRIPTION
The application fails to compile when trying to run the demo code locally using ```npm run start```.

Below is the snapshot of the issue:
![image](https://user-images.githubusercontent.com/37979839/42727276-32195874-87c1-11e8-8502-a40c1b33754b.png)

The ```ng serve``` command does not create a ```dist``` folder.
```ngx-clipboard``` is present under ```node_modules``` and hence ```paths``` property is not required.