### PR TITLE
feat(ssr): Differentiate between browser and server for SSR

### DIFF
--- a/projects/ngx-clipboard/src/lib/ngx-clipboard.module.ts
+++ b/projects/ngx-clipboard/src/lib/ngx-clipboard.module.ts
@@ -2,15 +2,15 @@ import { ClipboardDirective } from './ngx-clipboard.directive';
 import { CLIPBOARD_SERVICE_PROVIDER } from './ngx-clipboard.service';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { NgxWindowTokenModule } from 'ngx-window-token';
+import { WINDOW_PROVIDERS } from 'ngx-window-token';
 export * from './ngx-clipboard.directive';
 export * from './ngx-clipboard.service';
 
 @NgModule({
-  imports: [CommonModule, NgxWindowTokenModule],
+  imports: [CommonModule],
   // tslint:disable-next-line:object-literal-sort-keys
   declarations: [ClipboardDirective],
   exports: [ClipboardDirective],
-  providers: [CLIPBOARD_SERVICE_PROVIDER]
+  providers: [CLIPBOARD_SERVICE_PROVIDER, WINDOW_PROVIDERS]
 })
 export class ClipboardModule {}

--- a/projects/ngx-clipboard/src/lib/ngx-clipboard.service.ts
+++ b/projects/ngx-clipboard/src/lib/ngx-clipboard.service.ts
@@ -1,11 +1,17 @@
-import { Inject, Injectable, InjectionToken, Optional, SkipSelf } from '@angular/core';
+import { Inject, Injectable, InjectionToken, Optional, SkipSelf, PLATFORM_ID } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
-import { WINDOW } from 'ngx-window-token';
+import { isPlatformBrowser } from '@angular/common';
+import { WindowRef } from 'ngx-window-token';
 
 @Injectable()
 export class ClipboardService {
     private tempTextArea: HTMLTextAreaElement | undefined;
-    constructor(@Inject(DOCUMENT) public document: any, @Inject(WINDOW) private window: any) {}
+
+    constructor(
+        @Inject(DOCUMENT) public document: any,
+        private window: WindowRef,
+        @Inject(PLATFORM_ID) private platformId: Object) {}
+
     public get isSupported(): boolean {
         return !!this.document.queryCommandSupported && !!this.document.queryCommandSupported('copy');
     }
@@ -25,10 +31,12 @@ export class ClipboardService {
      */
     public copyFromInputElement(targetElm: HTMLInputElement | HTMLTextAreaElement): boolean {
         try {
-            this.selectTarget(targetElm);
-            const re = this.copyText();
-            this.clearSelection(targetElm, this.window);
-            return re && this.isCopySuccessInIE11();
+            if (isPlatformBrowser(this.platformId)) {
+                this.selectTarget(targetElm);
+                const re = this.copyText();
+                this.clearSelection(targetElm, this.window.nativeWindow);
+                return re && this.isCopySuccessInIE11();
+            }
         } catch (error) {
             return false;
         }
@@ -36,10 +44,12 @@ export class ClipboardService {
 
     // this is for IE11 return true even if copy fail
     isCopySuccessInIE11() {
-        const clipboardData = this.window['clipboardData'];
-        if (clipboardData && clipboardData.getData) {
-            if (!clipboardData.getData('Text')) {
-                return false;
+        if (isPlatformBrowser(this.platformId)) {
+            const clipboardData = this.window.nativeWindow['clipboardData'];
+            if (clipboardData && clipboardData.getData) {
+                if (!clipboardData.getData('Text')) {
+                    return false;
+                }
             }
         }
         return true;
@@ -49,79 +59,93 @@ export class ClipboardService {
      * Creates a fake textarea element, sets its value from `text` property,
      * and makes a selection on it.
      */
-    public copyFromContent(content: string, container: HTMLElement = this.window.document.body) {
-        // check if the temp textarea is still belong the current container.
-        // In case we have multiple places using ngx-clipboard, one is in a modal using container but the other one is not.
-        if (this.tempTextArea && !container.contains(this.tempTextArea)) {
-            this.destroy(this.tempTextArea.parentElement);
-        }
-
-        if (!this.tempTextArea) {
-            this.tempTextArea = this.createTempTextArea(this.document, this.window);
-            try {
-                container.appendChild(this.tempTextArea);
-            } catch (error) {
-                throw new Error('Container should be a Dom element');
+    public copyFromContent(content: string, container: HTMLElement) {
+        if (isPlatformBrowser(this.platformId)) {
+            container = container || this.window.nativeWindow.document.body;
+            // check if the temp textarea is still belong the current container.
+            // In case we have multiple places using ngx-clipboard, one is in a modal using container but the other one is not.
+            if (this.tempTextArea && !container.contains(this.tempTextArea)) {
+                this.destroy(this.tempTextArea.parentElement);
             }
+
+            if (!this.tempTextArea) {
+                this.tempTextArea = this.createTempTextArea(this.document, this.window.nativeWindow);
+                try {
+                    container.appendChild(this.tempTextArea);
+                } catch (error) {
+                    throw new Error('Container should be a Dom element');
+                }
+            }
+            this.tempTextArea.value = content;
+            return this.copyFromInputElement(this.tempTextArea);
         }
-        this.tempTextArea.value = content;
-        return this.copyFromInputElement(this.tempTextArea);
     }
 
     // remove temporary textarea if any
-    public destroy(container: HTMLElement = this.window.document.body) {
-        if (this.tempTextArea) {
-            container.removeChild(this.tempTextArea);
-            // removeChild doesn't remove the reference from memory
-            this.tempTextArea = undefined;
+    public destroy(container: HTMLElement) {
+        if (isPlatformBrowser(this.platformId)) {
+            container = container || this.window.nativeWindow.document.body;
+            if (this.tempTextArea) {
+                container.removeChild(this.tempTextArea);
+                // removeChild doesn't remove the reference from memory
+                this.tempTextArea = undefined;
+            }
         }
     }
 
     // select the target html input element
     private selectTarget(inputElement: HTMLInputElement | HTMLTextAreaElement): number | undefined {
-        inputElement.select();
-        inputElement.setSelectionRange(0, inputElement.value.length);
-        return inputElement.value.length;
+        if (isPlatformBrowser(this.platformId)) {
+            inputElement.select();
+            inputElement.setSelectionRange(0, inputElement.value.length);
+            return inputElement.value.length;
+        }
     }
 
     private copyText(): boolean {
-        return this.document.execCommand('copy');
+        if (isPlatformBrowser(this.platformId)) {
+            return this.document.execCommand('copy');
+        }
     }
     // Removes current selection and focus from `target` element.
     private clearSelection(inputElement: HTMLInputElement | HTMLTextAreaElement, window: Window) {
-        // tslint:disable-next-line:no-unused-expression
-        inputElement && inputElement.blur();
-        window.getSelection().removeAllRanges();
+        if (isPlatformBrowser(this.platformId)) {
+            // tslint:disable-next-line:no-unused-expression
+            inputElement && inputElement.blur();
+            window.getSelection().removeAllRanges();
+        }
     }
 
     // create a fake textarea for copy command
     private createTempTextArea(doc: Document, window: Window): HTMLTextAreaElement {
-        const isRTL = doc.documentElement.getAttribute('dir') === 'rtl';
-        let ta: HTMLTextAreaElement;
-        ta = doc.createElement('textarea');
-        // Prevent zooming on iOS
-        ta.style.fontSize = '12pt';
-        // Reset box model
-        ta.style.border = '0';
-        ta.style.padding = '0';
-        ta.style.margin = '0';
-        // Move element out of screen horizontally
-        ta.style.position = 'absolute';
-        ta.style[isRTL ? 'right' : 'left'] = '-9999px';
-        // Move element to the same position vertically
-        const yPosition = window.pageYOffset || doc.documentElement.scrollTop;
-        ta.style.top = yPosition + 'px';
-        ta.setAttribute('readonly', '');
-        return ta;
+        if (isPlatformBrowser(this.platformId)) {
+            const isRTL = doc.documentElement.getAttribute('dir') === 'rtl';
+            let ta: HTMLTextAreaElement;
+            ta = doc.createElement('textarea');
+            // Prevent zooming on iOS
+            ta.style.fontSize = '12pt';
+            // Reset box model
+            ta.style.border = '0';
+            ta.style.padding = '0';
+            ta.style.margin = '0';
+            // Move element out of screen horizontally
+            ta.style.position = 'absolute';
+            ta.style[isRTL ? 'right' : 'left'] = '-9999px';
+            // Move element to the same position vertically
+            const yPosition = window.pageYOffset || doc.documentElement.scrollTop;
+            ta.style.top = yPosition + 'px';
+            ta.setAttribute('readonly', '');
+            return ta;
+        }
     }
 }
 // this pattern is mentioned in https://github.com/angular/angular/issues/13854 in #43
-export function CLIPBOARD_SERVICE_PROVIDER_FACTORY(doc: Document, win: Window, parentDispatcher: ClipboardService) {
-    return parentDispatcher || new ClipboardService(doc, win);
+export function CLIPBOARD_SERVICE_PROVIDER_FACTORY(doc: Document, win: WindowRef, parentDispatcher: ClipboardService, platformId: Object) {
+    return parentDispatcher || new ClipboardService(doc, win, platformId);
 }
 
 export const CLIPBOARD_SERVICE_PROVIDER = {
-    deps: [DOCUMENT as InjectionToken<Document>, WINDOW as InjectionToken<Window>, [new Optional(), new SkipSelf(), ClipboardService]],
+    deps: [DOCUMENT as InjectionToken<Document>, WindowRef, [new Optional(), new SkipSelf(), ClipboardService], PLATFORM_ID],
     provide: ClipboardService,
     useFactory: CLIPBOARD_SERVICE_PROVIDER_FACTORY
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,19 +187,22 @@
   dependencies:
     tslib "^1.9.0"
 
-"@clr/angular@^0.12.10":
-  version "0.12.10"
-  resolved "https://registry.yarnpkg.com/@clr/angular/-/angular-0.12.10.tgz#aab495e6067a066d1fd7c7f8af20b8a80e558816"
+"@clr/angular@^0.12.11":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@clr/angular/-/angular-0.12.15.tgz#d830e5eb980037998f9c7c0c1f28108d0f10b3b9"
+  integrity sha512-tSzlugHR4a6PCfY2pHiyREUbvXO36/yGb0TmNHfZyMwbJYtt/pmBzHn6/fEg+0sAlI3vKuFUkNywuiV353WEwQ==
   dependencies:
     tslib "^1.9.0"
 
-"@clr/icons@^0.12.10":
-  version "0.12.10"
-  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-0.12.10.tgz#10e41ab0076b508f283c82796973d5a37976e8c2"
+"@clr/icons@^0.12.11":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-0.12.15.tgz#566864faddc52f3ef41ab54e4a476bcb61604382"
+  integrity sha512-er/QkdYTWmx+wSXN75hnY/lfYMvJ8zX309L6x5PnyPRP8HSb+yjZuhkZefgQXRyRM0JZuNT9zohl53zGpiNQbA==
 
-"@clr/ui@^0.12.10":
-  version "0.12.10"
-  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-0.12.10.tgz#aba591dfe528a8db5c0ee2d4fbd936cac1c16ccf"
+"@clr/ui@^0.12.11":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-0.12.15.tgz#7f2db569ba21fd57e3f2882dfa2de94a8c57ca1e"
+  integrity sha512-m3SXcYQNGbrFewuXHczYhnXozNIDY7VEnRIhcDbYjvqamoEQUzeEBfmy19w/kXaF1cIJW3NSkFukkqCEycU6aA==
 
 "@ngtools/json-schema@^1.1.0":
   version "1.1.0"
@@ -3714,9 +3717,10 @@ karma-jasmine-html-reporter@^0.2.2:
   dependencies:
     karma-jasmine "^1.0.2"
 
-karma-jasmine@^1.0.2, karma-jasmine@~1.1.1:
+karma-jasmine@^1.0.2, karma-jasmine@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-1.1.2.tgz#394f2b25ffb4a644b9ada6f22d443e2fd08886c3"
+  integrity sha1-OU8rJf+0pkS5rabyLUQ+L9CIhsM=
 
 karma-source-map-support@^1.2.0:
   version "1.3.0"
@@ -4332,16 +4336,24 @@ ng-packagr@^3.0.0:
     uglify-js "^3.0.7"
     update-notifier "^2.3.0"
 
-ngx-clipboard@^11.1.6:
-  version "11.1.6"
-  resolved "https://registry.yarnpkg.com/ngx-clipboard/-/ngx-clipboard-11.1.6.tgz#43fbf34d6438be0c37c369817139a99ce79fb6cd"
+ngx-clipboard@^11.1.7:
+  version "11.1.9"
+  resolved "https://registry.yarnpkg.com/ngx-clipboard/-/ngx-clipboard-11.1.9.tgz#a391853dc49e436de407260863a2c814d73a9332"
+  integrity sha512-xF54Ibt/04g2B5SnYylNz7ESP1/thuC7odo+0bKkgbCC873NaqP1VTVx/umh/cnezlXKu8zuWNzzg05tvfgaJg==
   dependencies:
-    ngx-window-token "^1.0.0"
+    ngx-window-token "^1.0.2"
     tslib "^1.9.0"
 
 ngx-window-token@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ngx-window-token/-/ngx-window-token-1.0.0.tgz#12acb174fbbcffa5c60b3fea5a6ea78cc3304793"
+  dependencies:
+    tslib "^1.9.0"
+
+ngx-window-token@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ngx-window-token/-/ngx-window-token-1.0.2.tgz#2ebadd300fee1f61eb8b851b0ad97b1f46f5e4cc"
+  integrity sha512-bFgvi7MYSK1p4b3Mqvn9+biXaO8QDEbpP2sEMSwr0Zgrwh6zCO3F92a6SIIzusqpZBAhxyfVSqj3mO5qIxlM5Q==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
I am using this module in a server-side-rendering-app.
Since it is accessing `window` directly (through your package [ngx-window-token](https://github.com/maxisam/ngx-window-token)), it caused issues while rendering the app on the server-side.

I included the `isPlatformBrowser()` checks to prevent errors while trying to access `window`.

Since this package is depending on [ngx-window-token](https://github.com/maxisam/ngx-window-token), I also changed things there to differentiate between browser and server (see [#14](https://github.com/maxisam/ngx-window-token/pull/14)).

Because of the dependency, I am not sure about which steps to take to make this work.
Maybe I should publish the changed `ngx-window-token`, reference it here and as soon as the original `ngx-window-token` is updated, the dependency can be changed back to normal.
Maybe you can point me to the right direction.

Please let me know your thoughts :)