### PR TITLE
fix: container should be HTMLElement

### DIFF
--- a/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.ts
+++ b/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.ts
@@ -11,7 +11,7 @@ export class ClipboardDirective implements OnInit, OnDestroy {
     @Input('ngxClipboard')
     public targetElm: HTMLInputElement;
     @Input()
-    public container: HTMLInputElement;
+    public container: HTMLElement;
 
     @Input()
     public cbContent: string;


### PR DESCRIPTION
Container should be HTMLElement instead of `HTMLInputElement`. Otherwise with the option `fullTemplateTypeCheck`, we have an error with an `HTMLDivElement` being assigned to an `HTMLInputElement`.