### PR TITLE
fix(ngx-clipboard): add HTMLTextAreaElement type to targetElm

### DIFF
--- a/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.ts
+++ b/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.ts
@@ -9,7 +9,7 @@ import { ClipboardService } from './ngx-clipboard.service';
 export class ClipboardDirective implements OnInit, OnDestroy {
     // tslint:disable-next-line:no-input-rename
     @Input('ngxClipboard')
-    public targetElm: HTMLInputElement;
+    public targetElm: HTMLInputElement | HTMLTextAreaElement;
     @Input()
     public container: HTMLElement;
 


### PR DESCRIPTION
Add TextArea type to this element because it is also valid 