### PR TITLE
fix: only execute clickListener if defined

### DIFF
--- a/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.ts
+++ b/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.ts
@@ -55,7 +55,9 @@ export class ClipboardDirective implements OnInit, OnDestroy {
     }
 
     public ngOnDestroy() {
-        this.clickListener();
+        if (this.clickListener) {
+            this.clickListener();
+        }
         this.clipboardSrv.destroy(this.container);
     }
 


### PR DESCRIPTION
Fixes #288 