### PR TITLE
Fix/missing success msg

### DIFF
--- a/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.spec.ts
+++ b/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.spec.ts
@@ -17,9 +17,9 @@ import { ClipboardService } from './ngx-clipboard.service';
     template: ` <span>PlaceHolder HTML to be Replaced</span> `
 })
 export class TestClipboardComponent {
-    public text = 'test';
+    public text = 'text';
     public isCopied: boolean;
-    public copySuccessMsg = 'Foo bar';
+    public copySuccessMsg = 'copySuccessMsg';
 }
 
 /**
@@ -120,7 +120,7 @@ describe('Directive: clipboard', () => {
             it(
                 'should push copy response to copySubject',
                 waitForAsync(() => {
-                    button.click();
+                    spy.and.returnValue(true);
                     const component = fixture.componentInstance;
                     clipboardService.copyResponse$.subscribe((res: IClipboardResponse) => {
                         expect(res).toBeDefined();
@@ -129,6 +129,7 @@ describe('Directive: clipboard', () => {
                         expect(res.successMessage).toEqual(component.copySuccessMsg);
                         expect(res.event).toBeDefined();
                     });
+                    button.click();
                 })
             );
         });

--- a/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.ts
+++ b/projects/ngx-clipboard/src/lib/ngx-clipboard.directive.ts
@@ -78,15 +78,13 @@ export class ClipboardDirective implements OnInit, OnDestroy {
     private handleResult(succeeded: boolean, copiedContent: string | undefined, event: MouseEvent): void {
         let response: IClipboardResponse = {
             isSuccess: succeeded,
+            content: copiedContent,
+            successMessage: this.cbSuccessMsg,
             event
         };
 
         if (succeeded) {
             if (this.cbOnSuccess.observers.length > 0) {
-                response = Object.assign(response, {
-                    content: copiedContent,
-                    successMessage: this.cbSuccessMsg
-                });
                 this.ngZone.run(() => {
                     this.cbOnSuccess.emit(response);
                 });


### PR DESCRIPTION
Updated handleResult() to publish always the same reponse.

Also fixed 'should push copy response to copySubject' test and added new tests to cover 'cbOnSuccess not used' case.